### PR TITLE
pin python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
 python:
-  - "2.7"
+  #- "2.7"
   - "3.6"
-branches:
-  only:
-    - master
+# branches:
+#  only:
+#    - master
 os:
   - linux
 #  - osx
@@ -26,7 +26,7 @@ install:
   - source activate hummingbird
   # Packages for testing
   - conda install pytest flake8
-  # Install Emu WPS
+  # Install WPS
   - python setup.py install
 before_script:
   # Start WPS service on port 5000 on 0.0.0.0

--- a/environment.yml
+++ b/environment.yml
@@ -4,9 +4,10 @@ channels:
 - conda-forge
 - defaults
 dependencies:
+- python=3.6
 - six
 # pywps
-- pywps=4.1
+- pywps=4.2
 - jinja2
 - click
 - psutil


### PR DESCRIPTION
## Overview

This PR fixes the conda env. Default python in miniconda is now 3.7 but we need to pin 3.6 (pywps, cdo).

## Related Issue / Discussion

## Additional Information

