### PR TITLE
fix rtd build failure (#30)

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,19 +1,21 @@
 name: hummingbird
 channels:
-#- defaults
-- conda-forge
+- birdhouse
+- defaults
 dependencies:
-- python>=3.6
+- python=3.7
 - pip
 # pywps
 - jinja2
 - click
 - psutil
-- xarray
-- netcdf4
+#- xarray
+#- netcdf4
 # compliance checker ioos
-- compliance-checker
+#- compliance-checker
+-  cf-units
 # tests
 - pytest
 - pip:
   - -e git+https://github.com/geopython/pywps@master#egg=pywps
+  - compliance-checker

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,8 +1,10 @@
+version: 2
 build:
     image: latest
-
 python:
-    version: 3.6
-
+    version: 3.7
+    install:
+      - method: setuptools
+        path: .
 conda:
-    file: environment.yml
+  environment: docs/environment.yml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-pywps>=4.0.0
+pywps>=4.2.0
 jinja2
 click
 psutil
+compliance-checker


### PR DESCRIPTION
## Overview

This PR fixes #30.

Changes:

* Added conda `docs/environment.yml` for RTD build without conda-forge channel.
* Updated RTD config to version 2.

## Related Issue / Discussion

## Additional Information


